### PR TITLE
remove math dependency

### DIFF
--- a/OpenMicro/src/drv_pwm.c
+++ b/OpenMicro/src/drv_pwm.c
@@ -384,14 +384,12 @@ void init_timer( TIM_TypeDef* TIMx , int period)
 
 #include  <math.h>
 
-void pwm_set( uint8_t number , float pwm)
+void pwm_set( uint8_t number , float pwmf)
 {
-	pwm = pwm * PWMTOP ;
+	int pwm = pwmf * PWMTOP ;
 	
 	if ( pwm < 0 ) pwm = 0;
   if ( pwm > PWMTOP ) pwm = PWMTOP;
-	
-	pwm = roundf(pwm);
 	
 	TIM_OCInitStructure.TIM_Pulse = pwm;
 	

--- a/OpenMicro/src/sixaxis.c
+++ b/OpenMicro/src/sixaxis.c
@@ -380,7 +380,7 @@ void acc_cal(void)
 
 	for (int x = 0; x < 3; x++)
 	  {
-			accelcal[x] = roundf ( accelcal[x] ); 
+			accelcal[x] = (int) accelcal[x]; 
 		  limitf(&accelcal[x], 127);
 	  }
 

--- a/OpenMicro/src/util.c
+++ b/OpenMicro/src/util.c
@@ -28,15 +28,14 @@ THE SOFTWARE.
 #include "drv_time.h"
 
 // calculates the coefficient for lpf filter, times in the same units
-float lpfcalc( float sampleperiod , float filtertime)
-{
-	if ( sampleperiod <= 0 ) return 0;
-  if ( filtertime <= 0 ) return 1;
-   float ga = expf(-1.0f/( (1.0f/ sampleperiod) * (filtertime) ));
-	if (ga > 1) ga = 1;
+float lpfcalc(float sampleperiod, float filtertime) {
+	float ga = 1.0f - sampleperiod / filtertime;
+	if (ga > 1.0f)
+		ga = 1.0f;
+	if (ga < 0.0f)
+		ga = 0.0f;
 	return ga;
 }
-
 
 float mapf(float x, float in_min, float in_max, float out_min, float out_max)
 {


### PR DESCRIPTION
Yet another optimization proposition,

this patch removes remaining math lib dependencies, 
which reduces the ROM usage to ~14.2kB, at least while using gcc.
